### PR TITLE
Added python-netifaces dependency

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -14,7 +14,7 @@ apt-get update
 apt-get remove -y --purge scratch squeak-plugins-scratch squeak-vm wolfram-engine python-minecraftpi minecraft-pi sonic-pi oracle-java8-jdk python-serial
 
 #apt-get octoprint virtualenv
-apt-get -y --force-yes install python-virtualenv python-dev git python-numpy screen libts-bin
+apt-get -y --force-yes install python-virtualenv python-dev git python-numpy python-netifaces screen libts-bin
 
 pushd /home/pi
   


### PR DESCRIPTION
OctoPrint 1.2.x needs that.
